### PR TITLE
Move activities data to activities.json

### DIFF
--- a/src/activities.json
+++ b/src/activities.json
@@ -1,0 +1,56 @@
+{
+  "Chess Club": {
+    "description": "Learn strategies and compete in chess tournaments",
+    "schedule": "Fridays, 3:30 PM - 5:00 PM",
+    "max_participants": 12,
+    "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
+  },
+  "Programming Class": {
+    "description": "Learn programming fundamentals and build software projects",
+    "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
+    "max_participants": 20,
+    "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
+  },
+  "Gym Class": {
+    "description": "Physical education and sports activities",
+    "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
+    "max_participants": 30,
+    "participants": ["john@mergington.edu", "olivia@mergington.edu"]
+  },
+  "Soccer Team": {
+    "description": "Join the school soccer team and compete in matches",
+    "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
+    "max_participants": 22,
+    "participants": ["liam@mergington.edu", "noah@mergington.edu"]
+  },
+  "Basketball Team": {
+    "description": "Practice and play basketball with the school team",
+    "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
+    "max_participants": 15,
+    "participants": ["ava@mergington.edu", "mia@mergington.edu"]
+  },
+  "Art Club": {
+    "description": "Explore your creativity through painting and drawing",
+    "schedule": "Thursdays, 3:30 PM - 5:00 PM",
+    "max_participants": 15,
+    "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
+  },
+  "Drama Club": {
+    "description": "Act, direct, and produce plays and performances",
+    "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
+    "max_participants": 20,
+    "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
+  },
+  "Math Club": {
+    "description": "Solve challenging problems and participate in math competitions",
+    "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
+    "max_participants": 10,
+    "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
+  },
+  "Debate Team": {
+    "description": "Develop public speaking and argumentation skills",
+    "schedule": "Fridays, 4:00 PM - 5:30 PM",
+    "max_participants": 12,
+    "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+  }
+}

--- a/src/app.py
+++ b/src/app.py
@@ -8,6 +8,7 @@ for extracurricular activities at Mergington High School.
 from fastapi import FastAPI, HTTPException
 from fastapi.staticfiles import StaticFiles
 from fastapi.responses import RedirectResponse
+import json
 import os
 from pathlib import Path
 
@@ -19,63 +20,10 @@ current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
 
-# In-memory activity database
-activities = {
-    "Chess Club": {
-        "description": "Learn strategies and compete in chess tournaments",
-        "schedule": "Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 12,
-        "participants": ["michael@mergington.edu", "daniel@mergington.edu"]
-    },
-    "Programming Class": {
-        "description": "Learn programming fundamentals and build software projects",
-        "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
-        "max_participants": 20,
-        "participants": ["emma@mergington.edu", "sophia@mergington.edu"]
-    },
-    "Gym Class": {
-        "description": "Physical education and sports activities",
-        "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
-        "max_participants": 30,
-        "participants": ["john@mergington.edu", "olivia@mergington.edu"]
-    },
-    "Soccer Team": {
-        "description": "Join the school soccer team and compete in matches",
-        "schedule": "Tuesdays and Thursdays, 4:00 PM - 5:30 PM",
-        "max_participants": 22,
-        "participants": ["liam@mergington.edu", "noah@mergington.edu"]
-    },
-    "Basketball Team": {
-        "description": "Practice and play basketball with the school team",
-        "schedule": "Wednesdays and Fridays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["ava@mergington.edu", "mia@mergington.edu"]
-    },
-    "Art Club": {
-        "description": "Explore your creativity through painting and drawing",
-        "schedule": "Thursdays, 3:30 PM - 5:00 PM",
-        "max_participants": 15,
-        "participants": ["amelia@mergington.edu", "harper@mergington.edu"]
-    },
-    "Drama Club": {
-        "description": "Act, direct, and produce plays and performances",
-        "schedule": "Mondays and Wednesdays, 4:00 PM - 5:30 PM",
-        "max_participants": 20,
-        "participants": ["ella@mergington.edu", "scarlett@mergington.edu"]
-    },
-    "Math Club": {
-        "description": "Solve challenging problems and participate in math competitions",
-        "schedule": "Tuesdays, 3:30 PM - 4:30 PM",
-        "max_participants": 10,
-        "participants": ["james@mergington.edu", "benjamin@mergington.edu"]
-    },
-    "Debate Team": {
-        "description": "Develop public speaking and argumentation skills",
-        "schedule": "Fridays, 4:00 PM - 5:30 PM",
-        "max_participants": 12,
-        "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
-    }
-}
+# Load activities from JSON file
+_activities_path = current_dir / "activities.json"
+with open(_activities_path) as f:
+    activities = json.load(f)
 
 
 @app.get("/")


### PR DESCRIPTION
## Summary

Moves the hardcoded activities list out of `app.py` and into a dedicated `src/activities.json` file, so teachers can edit activities without touching Python code.

## Changes

- **`src/activities.json`** (new) — contains all 9 activities in JSON format
- **`src/app.py`** — replaced the hardcoded `activities` dict with a JSON loader:
  ```python
  with open(current_dir / "activities.json") as f:
      activities = json.load(f)
  ```

## Notes

- All existing API endpoints (`GET /activities`, `POST /signup`, `DELETE /unregister`) are unchanged and continue to work.
- No schema changes — the JSON structure matches the previous in-memory dict exactly.

Closes #3